### PR TITLE
Tabledrag style workarounds.

### DIFF
--- a/core.css
+++ b/core.css
@@ -175,6 +175,12 @@ a.close, a.close:hover {
   background:url(images/bleeds.png) -40px -120px no-repeat;
   }
 
+.tabledrag-processed caption {
+  display: none;
+}
+.tabledrag-handle + .form-type-checkbox {
+  margin-left: 2em;
+}
 
 table {
   width:100%;


### PR DESCRIPTION
- Hide caption on tabledrag tables so the tabledrag-toggle can be positioned.
- Extra margins for itoggles if they appear next to toggle-handles.