### PR TITLE
fix(ae_admin.js): Remove call to undefined resizeIframe method

### DIFF
--- a/js/ae_admin.js
+++ b/js/ae_admin.js
@@ -82,12 +82,6 @@ Drupal.behaviors.ae_admin.attach = function(context) {
       $('.form-item-submit-button-text').removeClass('form-active');
   });
 
-  // call resizeIframe (again) to set the height of the media-browser iframe
-  // after it is *fully* rendered
-  if(Drupal.media && Drupal.media.browser) {
-    setTimeout(Drupal.media.browser.resizeIframe, 1);
-  }
-
   $('.wizard-form', context).each(function() {
     $('.wizard-title .form-actions', this).sticky();
   });


### PR DESCRIPTION
The media module has removed that function several versions ago, and we didn’t notice. Now the call to `setTimeout(undefined, …)` yields a CSP error because it interprets the undefined value as empty string and this in turn as code to `eval`.